### PR TITLE
Security: bump @remix-run/node to ^2.17.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@prisma/client": "^5.11.0",
         "@remix-run/dev": "^2.7.1",
-        "@remix-run/node": "^2.7.1",
+        "@remix-run/node": "^2.17.4",
         "@remix-run/react": "^2.7.1",
         "@remix-run/serve": "^2.7.1",
         "@shopify/app-bridge-react": "^4.1.2",
@@ -3904,6 +3904,31 @@
         }
       }
     },
+    "node_modules/@remix-run/dev/node_modules/@remix-run/node": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.9.2.tgz",
+      "integrity": "sha512-2Mt2107pfelz4T+ziDBef3P4A7kgPqCDshnEYCVGxInivJ3HHwAKUcb7MhGa8uMMMA6LMWxbAPYNHPzC3iKv2A==",
+      "dependencies": {
+        "@remix-run/server-runtime": "2.9.2",
+        "@remix-run/web-fetch": "^4.4.2",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie-signature": "^1.1.0",
+        "source-map-support": "^0.5.21",
+        "stream-slice": "^0.1.2",
+        "undici": "^6.10.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/dev/node_modules/prettier": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
@@ -3978,11 +4003,10 @@
         }
       }
     },
-    "node_modules/@remix-run/node": {
+    "node_modules/@remix-run/express/node_modules/@remix-run/node": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.9.2.tgz",
       "integrity": "sha512-2Mt2107pfelz4T+ziDBef3P4A7kgPqCDshnEYCVGxInivJ3HHwAKUcb7MhGa8uMMMA6LMWxbAPYNHPzC3iKv2A==",
-      "license": "MIT",
       "dependencies": {
         "@remix-run/server-runtime": "2.9.2",
         "@remix-run/web-fetch": "^4.4.2",
@@ -4002,6 +4026,72 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/node": {
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.4.tgz",
+      "integrity": "sha512-9A29JaYiGHDEmaiQuD1IlO/TrQxnnkj98GpytihU+Nz6yTt6RwzzyMMqTAoasRd1dPD4OeSaSqbwkcim/eE76Q==",
+      "dependencies": {
+        "@remix-run/server-runtime": "2.17.4",
+        "@remix-run/web-fetch": "^4.4.2",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie-signature": "^1.1.0",
+        "source-map-support": "^0.5.21",
+        "stream-slice": "^0.1.2",
+        "undici": "^6.21.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/node/node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@remix-run/node/node_modules/@remix-run/server-runtime": {
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.4.tgz",
+      "integrity": "sha512-oCsFbPuISgh8KpPKsfBChzjcntvTz5L+ggq9VNYWX8RX3yA7OgQpKspRHOSxb05bw7m0Hx+L1KRHXjf3juKX8w==",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "@types/cookie": "^0.6.0",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.7.2",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3",
+        "turbo-stream": "2.4.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/node/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@remix-run/react": {
@@ -4059,6 +4149,31 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@remix-run/serve/node_modules/@remix-run/node": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.9.2.tgz",
+      "integrity": "sha512-2Mt2107pfelz4T+ziDBef3P4A7kgPqCDshnEYCVGxInivJ3HHwAKUcb7MhGa8uMMMA6LMWxbAPYNHPzC3iKv2A==",
+      "dependencies": {
+        "@remix-run/server-runtime": "2.9.2",
+        "@remix-run/web-fetch": "^4.4.2",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie-signature": "^1.1.0",
+        "source-map-support": "^0.5.21",
+        "stream-slice": "^0.1.2",
+        "undici": "^6.10.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@remix-run/server-runtime": {
@@ -15275,10 +15390,9 @@
       "license": "0BSD"
     },
     "node_modules/turbo-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.2.0.tgz",
-      "integrity": "sha512-FKFg7A0To1VU4CH9YmSMON5QphK0BXjSoiC7D9yMh+mEEbXLUP9qJ4hEt1qcjKtzncs1OpcnjZO8NgrlVbZH+g==",
-      "license": "ISC"
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.1.tgz",
+      "integrity": "sha512-v8kOJXpG3WoTN/+at8vK7erSzo6nW6CIaeOvNOkHQVDajfz1ZVeSxCbc6tOH4hrGZW7VUCV0TOXd8CPzYnYkrw=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   "dependencies": {
     "@prisma/client": "^5.11.0",
     "@remix-run/dev": "^2.7.1",
-    "@remix-run/node": "^2.7.1",
+    "@remix-run/node": "^2.17.4",
     "@remix-run/react": "^2.7.1",
     "@remix-run/serve": "^2.7.1",
-    "@shopify/cli": "3.62.0",
     "@shopify/app-bridge-react": "^4.1.2",
+    "@shopify/cli": "3.62.0",
     "@shopify/polaris": "^12.0.0",
     "@shopify/shopify-api": "^11.0.0",
     "@shopify/shopify-app-remix": "^3.0.0",


### PR DESCRIPTION
## Summary
This PR bumps vulnerable Remix/React Router Node packages to safe versions:
- @remix-run/node >= 2.17.2
- @react-router/node >= 7.9.4
- @remix-run/deno >= 2.17.2

## Context
This addresses a security advisory for the packages above.
- https://nvd.nist.gov/vuln/detail/CVE-2025-61686


## Updated packages
- @remix-run/node@^2.17.2